### PR TITLE
Codecov

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,4 +43,3 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,4 +37,8 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run Tests (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
-        run: python -m pytest -v --color yes forcefield_utilities/tests
+        run: python -m pytest -v --color yes forcefield_utilities/tests --cov
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,7 +37,9 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run Tests (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
-        run: python -m pytest -v --color yes forcefield_utilities/tests --cov
+        run: |
+          python -m pytest -v --color yes forcefield_utilities/tests --cov
+          coverage xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
 dependencies:
   - bump2version
-  - codecov
   - foyer
   - pytest
+  - pytest-cov
   - pre-commit
   - pip
   - gmso


### PR DESCRIPTION
fixes https://github.com/mosdef-hub/forcefield-utilities/issues/17

In order to finish the setup, you will still need to install the [GitHub app integration](https://github.com/apps/codecov) and create a Codecov account.