### PR TITLE
copy over ff.combining_rule

### DIFF
--- a/forcefield_utilities/foyer_xml.py
+++ b/forcefield_utilities/foyer_xml.py
@@ -653,5 +653,6 @@ class ForceField(FoyerXMLTag):
 
         ff.name = self.name
         ff.version = self.version
+        ff.combining_rule = self.combining_rule
 
         return ff


### PR DESCRIPTION
Currently, when converting from a foyer ff to a gmso ff, the combining rule is not copied over. This PR fixes that. 