### PR TITLE
Add functions to make forcefield-utilities functional as a backend loader

### DIFF
--- a/forcefield_utilities/gmso_xml.py
+++ b/forcefield_utilities/gmso_xml.py
@@ -10,7 +10,9 @@ from gmso.core.atom_type import AtomType as GMSOAtomType
 from gmso.core.bond_type import BondType as GMSOBondType
 from gmso.core.dihedral_type import DihedralType as GMSODihedralType
 from gmso.core.improper_type import ImproperType as GMSOImproperType
-from gmso.core.pairpotential_type import PairPotentialType as GMSOPairPotentialType
+from gmso.core.pairpotential_type import (
+    PairPotentialType as GMSOPairPotentialType,
+)
 from gmso.utils._constants import FF_TOKENS_SEPARATOR
 from pydantic import BaseModel, Field
 
@@ -898,7 +900,9 @@ class PairPotentialTypes(GMSOXMLChild):
                 frozenset(pairpotential_type_dict["parameters"]),
             )
 
-            gmso_pairpotential_type = GMSOPairPotentialType(**pairpotential_type_dict)
+            gmso_pairpotential_type = GMSOPairPotentialType(
+                **pairpotential_type_dict
+            )
             if gmso_pairpotential_type.member_types:
                 potentials["pairpotential_types"][
                     FF_TOKENS_SEPARATOR.join(

--- a/forcefield_utilities/gmso_xml.py
+++ b/forcefield_utilities/gmso_xml.py
@@ -10,6 +10,7 @@ from gmso.core.atom_type import AtomType as GMSOAtomType
 from gmso.core.bond_type import BondType as GMSOBondType
 from gmso.core.dihedral_type import DihedralType as GMSODihedralType
 from gmso.core.improper_type import ImproperType as GMSOImproperType
+from gmso.core.pairpotential_type import PairPotentialType as GMSOPairPotentialType
 from gmso.utils._constants import FF_TOKENS_SEPARATOR
 from pydantic import BaseModel, Field
 
@@ -897,7 +898,7 @@ class PairPotentialTypes(GMSOXMLChild):
                 frozenset(pairpotential_type_dict["parameters"]),
             )
 
-            gmso_pairpotential_type = GMSOBondType(**pairpotential_type_dict)
+            gmso_pairpotential_type = GMSOPairPotentialType(**pairpotential_type_dict)
             if gmso_pairpotential_type.member_types:
                 potentials["pairpotential_types"][
                     FF_TOKENS_SEPARATOR.join(

--- a/forcefield_utilities/gmso_xml.py
+++ b/forcefield_utilities/gmso_xml.py
@@ -20,9 +20,14 @@ from forcefield_utilities.utils import pad_with_wildcards
 
 reg = UnitRegistry()
 dim = u.dimensions.current_mks * u.dimensions.time
-conversion = 1*getattr(u.physical_constants, "elementary_charge").value
-reg.add("elementary_charge", base_value=conversion, dimensions=dim, tex_repr=r"\rm{e}")
-conversion = 1*getattr(u.physical_constants, "boltzmann_constant_mks").value
+conversion = 1 * getattr(u.physical_constants, "elementary_charge").value
+reg.add(
+    "elementary_charge",
+    base_value=conversion,
+    dimensions=dim,
+    tex_repr=r"\rm{e}",
+)
+conversion = 1 * getattr(u.physical_constants, "boltzmann_constant_mks").value
 dim = u.dimensions.energy / u.dimensions.temperature
 reg.add("kb", base_value=conversion, dimensions=dim, tex_repr=r"\rm{kb}")
 

--- a/forcefield_utilities/gmso_xml.py
+++ b/forcefield_utilities/gmso_xml.py
@@ -19,8 +19,8 @@ from forcefield_utilities.utils import pad_with_wildcards
 from unyt import UnitRegistry, Unit
 reg = UnitRegistry()
 dim = u.dimensions.current_mks * u.dimensions.time
-conversion = -1*getattr(u.physical_constants, "electron_charge").value #-1 due to sign of constant
-reg.add("electron_charge", base_value=conversion, dimensions=dim, tex_repr=r"\rm{e}")
+conversion = 1*getattr(u.physical_constants, "elementary_charge").value #-1 due to sign of constant
+reg.add("elementary_charge", base_value=conversion, dimensions=dim, tex_repr=r"\rm{e}")
 conversion = 1*getattr(u.physical_constants, "boltzmann_constant_mks").value
 dim = u.dimensions.energy / u.dimensions.temperature
 reg.add("kb", base_value=conversion, dimensions=dim, tex_repr=r"\rm{kb}")
@@ -964,7 +964,7 @@ class FFMetaData(GMSOXMLChild):
 
 def source_units(unit):
     try:
-        attach_unit = u.Unit(unit)
+        attach_unit = u.Unit(unit, registry=reg)
     except u.exceptions.UnitParseError:
         try:
             attach_unit = Unit("electron_charge", registry=reg)

--- a/forcefield_utilities/tests/test_xml_loader.py
+++ b/forcefield_utilities/tests/test_xml_loader.py
@@ -1,5 +1,7 @@
 import pytest
 
+from foyer.forcefield import get_available_forcefield_loaders
+
 from forcefield_utilities.tests.base_test import BaseTest
 from forcefield_utilities.tests.utils import get_test_file_path
 from forcefield_utilities.utils import get_package_file_path
@@ -15,6 +17,11 @@ class TestXMLLoader(BaseTest):
     def gmso_xml_loader(self):
         return GMSOFFs()
 
+    @pytest.mark.skipif(
+    condition="load_GAFF"
+    not in map(lambda func: func.__name__, get_available_forcefield_loaders()),
+    reason="GAFF Plugin is not installed",
+    )
     def test_load_gaff(self, foyer_xml_loader):
         foyer_xml_loader.get_ff("gaff")
         assert "gaff" in foyer_xml_loader.loaded_ffs


### PR DESCRIPTION
Adding in utility functions to switch to loading in GMSO xmls through forcefield-utilities. There are some minor differences in syntax in the the XMLS loaded from the two loaders, so a few changes have to made to make sure the GMSO tests are all sensible when testing the loading using the forcefields in GMSO.

See https://github.com/mosdef-hub/gmso/pull/690 for more info.