### PR TITLE
update mamba runner used for bleeding edge test

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,10 +57,10 @@ jobs:
         name: Checkout Branch / Pull Request
 
       - name: Install Mamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: environment-dev.yml
-          extra-specs: |
+          create-args: >-
             python=3.12
 
       - name: Clone GMSO


### PR DESCRIPTION
In the last PR I updated the CI.yaml to use the micromamba runner, but forgot to do it for the bleeding edge test. Hopefully this fixes the CI issue from the last PR.