### PR TITLE
reverse order of pydantic typing for Parameter.value

### DIFF
--- a/forcefield_utilities/gmso_xml.py
+++ b/forcefield_utilities/gmso_xml.py
@@ -144,7 +144,7 @@ class Parameter(GMSOXMLTag):
         ..., description="The name of the parameter", alias="name"
     )
 
-    value: Union[float, np.ndarray] = Field(
+    value: Union[np.ndarray, float] = Field(
         ..., description="The value of the parameter", alias="value"
     )
 


### PR DESCRIPTION
This PR aims to reduce pydantic validation warning:
```
gmso/tests/test_xml_handling.py: 1824 warnings
  /Users/calcraven/micromamba/envs/test-mbuild311/lib/python3.11/site-packages/pydantic/main.py:253: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
```
That occurs when trying to load a GMSOFFs ForceField object.