### PR TITLE
Replace importlib_resources with built-in importlib library

### DIFF
--- a/forcefield_utilities/utils.py
+++ b/forcefield_utilities/utils.py
@@ -9,9 +9,9 @@ def call_on_import(func):
 
 def get_package_file_path(from_package, relative_path):
     """Use source of a python package to locate and cache the address of a file."""
-    import importlib_resources
+    from importlib.resources import files
 
-    return str(importlib_resources.files(from_package) / relative_path)
+    return str(files(from_package) / relative_path)
 
 
 def deprecate_kwargs(deprecated_kwargs=None):


### PR DESCRIPTION
This replaces `importlib_resources` with the `importlib` library.

This won't pass until https://github.com/mosdef-hub/gmso/pull/919 is merged, and that won't pass until this is merged. I'll merge this one first, everything passes locally when I install GMSO from https://github.com/mosdef-hub/gmso/pull/919.