### PR TITLE
Better handling of empty atomtype virtualtype expressions

### DIFF
--- a/forcefield_utilities/gmso_xml.py
+++ b/forcefield_utilities/gmso_xml.py
@@ -22,6 +22,7 @@ from gmso.core.virtual_type import (
 )
 from gmso.core.virtual_type import VirtualType as GMSOVirtualType
 from gmso.utils._constants import FF_TOKENS_SEPARATOR
+from gmso.utils.expression import NullPotentialExpression
 from gmso.utils.ff_utils import _get_member_classes, _get_member_types
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -340,6 +341,16 @@ class AtomTypes(GMSOXMLChild):
                 atom_type_dict["mass"] = (
                     atom_type_dict["mass"] * default_units["mass"]
                 )
+            if (
+                atom_type_dict.get("expression") is None
+                and atom_type_dict.get("parameters") is None
+            ):
+                atom_type_dict["potential_expression"] = (
+                    NullPotentialExpression()
+                )
+                atom_type_dict.pop("expression", None)
+                atom_type_dict.pop("parameters", None)
+                atom_type_dict.pop("independent_variables", None)
             gmso_atom_type = GMSOAtomType(**atom_type_dict)
             element = atom_type.element
             if element:

--- a/forcefield_utilities/gmso_xml.py
+++ b/forcefield_utilities/gmso_xml.py
@@ -123,6 +123,8 @@ def register_identifiers(registry, identifier, for_type="AtomTypes"):
 @lru_cache(maxsize=128)
 def indep_vars(expr: str, dependent: frozenset) -> Set:
     """Given an expression and dependent variables, return independent variables for it."""
+    if not expr or expr == "":
+        return None
     dependent_symbols = frozenset(map(lambda x: sympy.symbols(x), dependent))
     return sympy.sympify(expr).free_symbols - dependent_symbols
 
@@ -280,8 +282,8 @@ class AtomTypes(GMSOXMLChild):
         None, description="The name for this atom type group", alias="name"
     )
 
-    expression: str = Field(
-        ...,
+    expression: Optional[str] = Field(
+        None,
         description="The expression for this atom type group",
         alias="expression",
     )
@@ -319,13 +321,15 @@ class AtomTypes(GMSOXMLChild):
 
             if "expression" not in atom_type_dict:
                 atom_type_dict["expression"] = self.expression
-            atom_type_dict["parameters"] = atom_type.parameters(units)
+            if atom_type_dict["expression"] is not None:  # Non Empty Expression
+                if atom_type.children:
+                    atom_type_dict["parameters"] = atom_type.parameters(units)
 
-            if not atom_type_dict.get("independent_variables"):
-                atom_type_dict["independent_variables"] = indep_vars(
-                    atom_type_dict["expression"],
-                    frozenset(atom_type_dict["parameters"]),
-                )
+                if not atom_type_dict.get("independent_variables"):
+                    atom_type_dict["independent_variables"] = indep_vars(
+                        atom_type_dict["expression"],
+                        frozenset(atom_type_dict["parameters"]),
+                    )
 
             if default_units.get("charge") and atom_type_dict.get("charge"):
                 atom_type_dict["charge"] = (
@@ -1265,10 +1269,16 @@ class VirtualSiteTypes(GMSOXMLChild):
             potentialDict = {}
             if self.potential_expression:
                 potentialDict["expression"] = self.potential_expression
-            if virtual_type.virtual_potential:
-                potentialDict["parameters"] = (
-                    virtual_type.virtual_potential.parameters(units)
-                )
+
+            if (
+                virtual_type.virtual_potential
+                and potentialDict["expression"] is not None
+            ):
+                if virtual_type.virtual_potential.children:
+                    potentialDict["parameters"] = (
+                        virtual_type.virtual_potential.parameters(units)
+                    )
+
             potentialDict["independent_variables"] = indep_vars(
                 potentialDict["expression"],
                 frozenset(potentialDict["parameters"]),
@@ -1280,14 +1290,19 @@ class VirtualSiteTypes(GMSOXMLChild):
             positionDict = {}
             if self.position_expression:
                 positionDict["expression"] = self.position_expression
-            if virtual_type.virtual_position:
-                positionDict["parameters"] = (
-                    virtual_type.virtual_position.parameters(units)
+            if (
+                virtual_type.virtual_position
+                and positionDict["expression"] is not None
+            ):
+                if virtual_type.virtual_position.children:
+                    positionDict["parameters"] = (
+                        virtual_type.virtual_position.parameters(units)
+                    )
+
+                positionDict["independent_variables"] = indep_vars(
+                    positionDict["expression"],
+                    frozenset(positionDict["parameters"]),
                 )
-            positionDict["independent_variables"] = indep_vars(
-                positionDict["expression"],
-                frozenset(positionDict["parameters"]),
-            )
             virtual_type_dict["virtual_position"] = GMSOVirtualPositionType(
                 **positionDict
             )

--- a/forcefield_utilities/tests/files/pairpotential.xml
+++ b/forcefield_utilities/tests/files/pairpotential.xml
@@ -1,0 +1,21 @@
+<ForceField version="0.0.1" name="No-Atype-Expression">
+    <FFMetaData combiningRule="lorentz">
+        <Units energy="kJ/mol" distance="nm" mass="amu" time="s" charge="coulomb"/>
+    </FFMetaData>
+    <AtomTypes>
+       <AtomType name="_A" element="_A" atomclass="_A" mass="1.0" charge="0.0" definition="_A" description="CG Bead">
+       </AtomType>
+    </AtomTypes>
+  <PairPotentialTypes expression="A * (1-(r/r_cut)) - γ">
+    <ParametersUnitDef parameter="A" unit="N"/>
+    <ParametersUnitDef parameter="r_cut" unit="nm"/>
+    <ParametersUnitDef parameter="γ" unit="amu/s"/>
+    <PairPotentialType name="HOOMDDPDForce" type1="_A" type2="_A">
+        <Parameters>
+            <Parameter name="A" value="40.0"/>
+	    <Parameter name="r_cut" value="1.0"/>
+	    <Parameter name="γ" value="8.0"/>
+        </Parameters>
+    </PairPotentialType>
+  </PairPotentialTypes>
+</ForceField>

--- a/forcefield_utilities/tests/test_gmso_xml.py
+++ b/forcefield_utilities/tests/test_gmso_xml.py
@@ -260,6 +260,17 @@ class TestListParameters(BaseTest):
             [0.0, 0.69551975, -0.023, 0.3734553, 0.0, 0.0] * u.kcal / u.mol,
         )
 
+    def test_pairpotential_params(self):
+        fn = get_test_file_path("pairpotential.xml")
+        ff = GMSOFFs().load(fn).to_gmso_ff()
+        atom_type = ff.atom_types["_A"]
+        assert atom_type.expression is None
+        pair_type = ff.pairpotential_types["_A~_A"]
+        params = pair_type.get_parameters()
+        assert u.allclose_units(params["A"], 40 * u.N)
+        assert u.allclose_units(params["r_cut"], 1 * u.nm)
+        assert u.allclose_units(params["γ"], 8 * u.amu / u.s)
+
 
 class TestVirtualSites(BaseTest):
     @pytest.fixture(scope="session")


### PR DESCRIPTION
Essentially less strict handling of empty atomtypes, skipping validation/parameters checks and setting to None if when reading a gmso_xml. This behavior will be necessary when creating virtual_sites without potential expressions, or atomtypes where the potential information is stored as a pair potential.