### PR TITLE
Bump python test cov from 3.11-3.14, update action versions in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,17 +17,17 @@ jobs:
     strategy:
       matrix:
         os: [ macOS-latest, ubuntu-latest ]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Checkout Branch
 
       - name: Install Mamba
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: environment-dev.yml
           create-args: >-
@@ -42,7 +42,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
 
   bleeding-edge-test:
     if: github.event.pull_request.draft == false
@@ -53,11 +53,11 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Checkout Branch / Pull Request
 
       - name: Install Mamba
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: environment-dev.yml
           create-args: >-

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,9 +2,8 @@ name: forcefields-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10,<=3.13
-  - boltons
-  - numpy>=2.0,<2.3
+  - python>=3.11,<=3.14
+  - numpy>=2.0,<2.6
   - sympy
   - unyt>=2.9.5
   - boltons
@@ -13,12 +12,12 @@ dependencies:
   - intermol
   - mdtraj
   - pydantic>=2
-  - networkx
+  - networkx>=2.5
   - nglview>=3
   - pytest
   - garnett>=0.7.1
   - openff-toolkit-base>0.16.7
-  - openmm
+  - openmm>=8.4
   - gsd>=2.9
   - freud>=3.2
   - parmed>=3.4.3


### PR DESCRIPTION
This updates the dev and testing environment to match recent changes to mbuild, foyer and gsmo. Adding python 3.14 and dropping 3.10 from testing coverage, and bumping up the maximum numpy pin.